### PR TITLE
Adding `color-no-hex` rule 

### DIFF
--- a/docs/rules/color-no-hex.md
+++ b/docs/rules/color-no-hex.md
@@ -1,19 +1,12 @@
 # Prevent the use of static hex color values (`@metamask/design-tokens/color-no-hex`)
 
-This rule discourages the direct use of hexadecimal color codes in your styles, promoting the adoption of a centralized approach to color management via [design tokens](https://github.com/MetaMask/design-tokens) or variables. By enforcing the use of [design tokens](https://github.com/MetaMask/design-tokens) for colors, this rule aids in ensuring consistency, scalability, and ease of maintenance across your project's UI.
+This rule discourages the direct use of hexadecimal color codes in your styles, promoting the adoption of a centralized approach to color management via [design tokens](https://github.com/MetaMask/design-tokens). By enforcing the use of [design tokens](https://github.com/MetaMask/design-tokens) for colors, this rule aids in ensuring consistency, design system alignment, scalability, and ease of maintenance across your project's UI.
 
 ## Rule Details
 
-The `color-no-hex` rule is aimed at encouraging the use of abstracted color definitions, such as [design tokens](https://github.com/MetaMask/design-tokens) or CSS variables, instead of hardcoded hexadecimal color values. This practice facilitates theming, reusability, and easier updates to the color palette.
+The `color-no-hex` rule is aimed at encouraging the use of [design tokens](https://github.com/MetaMask/design-tokens), instead of hardcoded hexadecimal color values. This practice facilitates theming, reusability, and easier updates to the color palette.
 
 Examples of **incorrect** code for this rule:
-
-```css
-/* Using hex color values directly */
-.selector {
-  color: #e06470;
-}
-```
 
 ```jsx
 // In a JSX file
@@ -22,25 +15,19 @@ Examples of **incorrect** code for this rule:
 
 Examples of **correct** code for this rule:
 
-```css
-/* Using CSS variables */
-:root {
-  --error-color: #e06470;
-}
-
-.selector {
-  color: var(--error-color);
-}
+```jsx
+// Using design token CSS variables
+<div style={{ color: 'var(--color-error-default)' }}>...</div>
 ```
 
 ```jsx
-// In a JSX file
-<div style={{ color: 'var(--error-color)' }}>...</div>
+// Using design token CSS-in-JS variables
+<div style={{ color: theme.error.default }}>...</div>
 ```
 
 ## Options
 
-This rule does not accept any options. Its sole purpose is to flag the use of inline hexadecimal color values in favor of abstracted color definitions like CSS variables or [design tokens](https://github.com/MetaMask/design-tokens).
+This rule does not accept any options. Its sole purpose is to flag the use of inline hexadecimal color values in favor of [design tokens](https://github.com/MetaMask/design-tokens) generated styles.
 
 ## Example Configuration
 
@@ -54,7 +41,7 @@ This rule does not accept any options. Its sole purpose is to flag the use of in
 
 You might choose not to enable this rule if:
 
-- Your project has not adopted a design system or does not use CSS variables/[design tokens](https://github.com/MetaMask/design-tokens) for colors.
+- Your project has not adopted the MetaMask design system.
 - There are specific cases where direct hexadecimal color usage is necessary and cannot be abstracted (although these cases should be rare and well-justified).
 
 Adhering to this rule helps ensure that your project's color definitions are centralized and easily manageable, making it simpler to adapt or re-theme your application as needed.

--- a/docs/rules/color-no-hex.md
+++ b/docs/rules/color-no-hex.md
@@ -42,6 +42,19 @@ This rule does not accept any options. Its sole purpose is to flag the use of in
 You might choose not to enable this rule if:
 
 - Your project has not adopted the MetaMask design system.
-- There are specific cases where direct hexadecimal color usage is necessary and cannot be abstracted (although these cases should be rare and well-justified).
+- There are specific cases where direct hexadecimal color usage is necessary and cannot be abstracted. This includes assets like SVG graphics, although such exceptions should be rare and well-justified. In such cases, you can disable the rule for specific files or folders by adding overrides in your ESLint configuration. For example, to disable the rule in asset files or folders, you can use:
 
-Adhering to this rule helps ensure that your project's color definitions are centralized and easily manageable, making it simpler to adapt or re-theme your application as needed.
+```json
+"overrides": [
+  {
+    "files": ["path/to/assets/*", "another/path/to/specific/files/*"],
+    "rules": {
+      "@metamask/design-tokens/color-no-hex": "off"
+    }
+  }
+]
+```
+
+This configuration allows you to selectively apply the rule where it makes sense, while accommodating necessary exceptions.
+
+Adhering to this rule helps ensure that your project's color definitions are centralized and easily manageable, facilitating simpler adaptations or re-theming of your application as needed.

--- a/docs/rules/color-no-hex.md
+++ b/docs/rules/color-no-hex.md
@@ -1,0 +1,60 @@
+# Prevent the use of static hex color values (`@metamask/design-tokens/color-no-hex`)
+
+This rule discourages the direct use of hexadecimal color codes in your styles, promoting the adoption of a centralized approach to color management via [design tokens](https://github.com/MetaMask/design-tokens) or variables. By enforcing the use of [design tokens](https://github.com/MetaMask/design-tokens) for colors, this rule aids in ensuring consistency, scalability, and ease of maintenance across your project's UI.
+
+## Rule Details
+
+The `color-no-hex` rule is aimed at encouraging the use of abstracted color definitions, such as [design tokens](https://github.com/MetaMask/design-tokens) or CSS variables, instead of hardcoded hexadecimal color values. This practice facilitates theming, reusability, and easier updates to the color palette.
+
+Examples of **incorrect** code for this rule:
+
+```css
+/* Using hex color values directly */
+.selector {
+  color: #e06470;
+}
+```
+
+```jsx
+// In a JSX file
+<div style={{ color: '#E06470' }}>...</div>
+```
+
+Examples of **correct** code for this rule:
+
+```css
+/* Using CSS variables */
+:root {
+  --error-color: #e06470;
+}
+
+.selector {
+  color: var(--error-color);
+}
+```
+
+```jsx
+// In a JSX file
+<div style={{ color: 'var(--error-color)' }}>...</div>
+```
+
+## Options
+
+This rule does not accept any options. Its sole purpose is to flag the use of inline hexadecimal color values in favor of abstracted color definitions like CSS variables or [design tokens](https://github.com/MetaMask/design-tokens).
+
+## Example Configuration
+
+```json
+{
+  "@metamask/design-tokens/color-no-hex": "warn"
+}
+```
+
+## When Not To Use It
+
+You might choose not to enable this rule if:
+
+- Your project has not adopted a design system or does not use CSS variables/[design tokens](https://github.com/MetaMask/design-tokens) for colors.
+- There are specific cases where direct hexadecimal color usage is necessary and cannot be abstracted (although these cases should be rare and well-justified).
+
+Adhering to this rule helps ensure that your project's color definitions are centralized and easily manageable, making it simpler to adapt or re-theme your application as needed.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-import { noDeprecatedClassnames } from './rules';
+import { noDeprecatedClassnames, colorNoHex } from './rules';
 
 export const rules = {
   'no-deprecated-classnames': noDeprecatedClassnames,
+  'color-no-hex': colorNoHex,
 };

--- a/src/rules/color-no-hex.ts
+++ b/src/rules/color-no-hex.ts
@@ -1,6 +1,4 @@
 import type { Rule } from 'eslint';
-import type { Literal, TemplateLiteral } from 'estree';
-
 /**
  * Regular expression to match hex color values.
  * Added capturing group to extract the hex value.
@@ -23,7 +21,7 @@ export const colorNoHex: Rule.RuleModule = {
   },
   create(context) {
     return {
-      Literal(node: Literal) {
+      Literal(node) {
         if (typeof node.value === 'string') {
           const matches = node.value.match(hexColorRegex);
           if (matches) {
@@ -35,7 +33,7 @@ export const colorNoHex: Rule.RuleModule = {
           }
         }
       },
-      TemplateLiteral(node: TemplateLiteral) {
+      TemplateLiteral(node) {
         node.quasis.forEach((part) => {
           const matches = part.value.raw.match(hexColorRegex);
           if (matches) {

--- a/src/rules/color-no-hex.ts
+++ b/src/rules/color-no-hex.ts
@@ -15,7 +15,7 @@ export const colorNoHex: Rule.RuleModule = {
     docs: {
       description: 'Prevent the use of hex color values.',
       recommended: true,
-      url: 'https://github.com/your-plugin-url-here#color-no-hex',
+      url: 'https://github.com/MetaMask/eslint-plugin-design-tokens/blob/main/docs/rules/color-no-hex.md',
     },
     schema: [], // This rule does not take any options
   },

--- a/src/rules/color-no-hex.ts
+++ b/src/rules/color-no-hex.ts
@@ -28,7 +28,7 @@ export const colorNoHex: Rule.RuleModule = {
             const hexValue = matches[1] as string; // Type assertion to string
             context.report({
               node,
-              message: `'${hexValue}' Hex color values are not allowed. Consider using design tokens instead. For more information, visit: https://github.com/MetaMask/design-tokens or reach out to the design system team #metamask-design-system.`,
+              message: `'${hexValue}' Hex color values are not allowed. Consider using design tokens instead. For support reach out to the design system team #metamask-design-system on Slack.`,
             });
           }
         }
@@ -40,7 +40,7 @@ export const colorNoHex: Rule.RuleModule = {
             const hexValue = matches[1] as string; // Type assertion to string
             context.report({
               node: part,
-              message: `'${hexValue}' Hex color values are not allowed. Consider using design tokens instead. For more information, visit: https://github.com/MetaMask/design-tokens or reach out to the design system team #metamask-design-system.`,
+              message: `'${hexValue}' Hex color values are not allowed. Consider using design tokens instead. For support reach out to the design system team #metamask-design-system on Slack.`,
             });
           }
         });

--- a/src/rules/color-no-hex.ts
+++ b/src/rules/color-no-hex.ts
@@ -1,0 +1,52 @@
+import type { Rule } from 'eslint';
+import type { Literal, TemplateLiteral } from 'estree';
+
+/**
+ * Regular expression to match hex color values.
+ * Added capturing group to extract the hex value.
+ * Using 'u' flag for Unicode support.
+ */
+const hexColorRegex = /(#\p{Hex_Digit}{3,6})\b/u;
+
+/**
+ * Rule to prevent the use of hex color values.
+ */
+export const colorNoHex: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Prevent the use of hex color values.',
+      recommended: true,
+      url: 'https://github.com/your-plugin-url-here#color-no-hex',
+    },
+    schema: [], // This rule does not take any options
+  },
+  create(context) {
+    return {
+      Literal(node: Literal) {
+        if (typeof node.value === 'string') {
+          const matches = node.value.match(hexColorRegex);
+          if (matches) {
+            const hexValue = matches[1] as string; // Type assertion to string
+            context.report({
+              node,
+              message: `'${hexValue}' Hex color values are not allowed. Consider using design tokens instead. For more information, visit: https://github.com/MetaMask/design-tokens or reach out to the design system team #metamask-design-system.`,
+            });
+          }
+        }
+      },
+      TemplateLiteral(node: TemplateLiteral) {
+        node.quasis.forEach((part) => {
+          const matches = part.value.raw.match(hexColorRegex);
+          if (matches) {
+            const hexValue = matches[1] as string; // Type assertion to string
+            context.report({
+              node: part,
+              message: `'${hexValue}' Hex color values are not allowed. Consider using design tokens instead. For more information, visit: https://github.com/MetaMask/design-tokens or reach out to the design system team #metamask-design-system.`,
+            });
+          }
+        });
+      },
+    };
+  },
+};

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,1 +1,2 @@
 export { noDeprecatedClassnames } from './no-deprecated-classnames';
+export { colorNoHex } from './color-no-hex';

--- a/src/rules/no-deprecated-classnames.ts
+++ b/src/rules/no-deprecated-classnames.ts
@@ -20,7 +20,7 @@ export const noDeprecatedClassnames: Rule.RuleModule = {
       description: 'No deprecated classnames allowed',
       recommended: false,
       // Make sure to replace the URL with the actual location of your rule's documentation
-      url: 'https://github.com/MetaMask/eslint-plugin-design-tokens?tab=readme-ov-file#eslint-plugin-design-tokens-',
+      url: 'https://github.com/MetaMask/eslint-plugin-design-tokens/blob/main/docs/rules/no-deprecated-classnames.md',
     },
     // Define the schema to accept an object of deprecated classnames
     schema: [

--- a/tests/rules/color-no-hex.spec.ts
+++ b/tests/rules/color-no-hex.spec.ts
@@ -24,7 +24,7 @@ ruleTester.run('color-no-hex', colorNoHex, {
       code: `const color = "#abc";`,
       errors: [
         {
-          message: `'#abc' Hex color values are not allowed. Consider using design tokens instead. For more information, visit: https://github.com/MetaMask/design-tokens or reach out to the design system team #metamask-design-system.`,
+          message: `'#abc' Hex color values are not allowed. Consider using design tokens instead. For support reach out to the design system team #metamask-design-system on Slack.`,
         },
       ],
     },
@@ -32,7 +32,7 @@ ruleTester.run('color-no-hex', colorNoHex, {
       code: `const backgroundColor = "#123456";`,
       errors: [
         {
-          message: `'#123456' Hex color values are not allowed. Consider using design tokens instead. For more information, visit: https://github.com/MetaMask/design-tokens or reach out to the design system team #metamask-design-system.`,
+          message: `'#123456' Hex color values are not allowed. Consider using design tokens instead. For support reach out to the design system team #metamask-design-system on Slack.`,
         },
       ],
     },
@@ -41,7 +41,7 @@ ruleTester.run('color-no-hex', colorNoHex, {
       code: `const borderColor = \`#abcdef\`;`,
       errors: [
         {
-          message: `'#abcdef' Hex color values are not allowed. Consider using design tokens instead. For more information, visit: https://github.com/MetaMask/design-tokens or reach out to the design system team #metamask-design-system.`,
+          message: `'#abcdef' Hex color values are not allowed. Consider using design tokens instead. For support reach out to the design system team #metamask-design-system on Slack.`,
         },
       ],
     },
@@ -49,7 +49,7 @@ ruleTester.run('color-no-hex', colorNoHex, {
       code: `const boxShadow = \`5px 5px 5px #888\`;`,
       errors: [
         {
-          message: `'#888' Hex color values are not allowed. Consider using design tokens instead. For more information, visit: https://github.com/MetaMask/design-tokens or reach out to the design system team #metamask-design-system.`,
+          message: `'#888' Hex color values are not allowed. Consider using design tokens instead. For support reach out to the design system team #metamask-design-system on Slack.`,
         },
       ],
     },

--- a/tests/rules/color-no-hex.spec.ts
+++ b/tests/rules/color-no-hex.spec.ts
@@ -1,0 +1,57 @@
+import { RuleTester } from 'eslint';
+
+import { colorNoHex } from '../../src/rules/color-no-hex'; // Adjust this import path to where your rule is actually defined
+
+const ruleTester = new RuleTester({
+  // eslint-disable-next-line no-restricted-globals
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('color-no-hex', colorNoHex, {
+  valid: [
+    `const color = "blue";`,
+    `const backgroundColor = "rgba(255, 255, 255, 0.5)";`,
+    `const borderColor = 'var(--border-color)';`,
+    // Template literals without hex colors
+    `const boxShadow = \`5px 5px 5px var(--shadow-color)\`;`,
+  ],
+  invalid: [
+    {
+      code: `const color = "#abc";`,
+      errors: [
+        {
+          message: `'#abc' Hex color values are not allowed. Consider using design tokens instead. For more information, visit: https://github.com/MetaMask/design-tokens or reach out to the design system team #metamask-design-system.`,
+        },
+      ],
+    },
+    {
+      code: `const backgroundColor = "#123456";`,
+      errors: [
+        {
+          message: `'#123456' Hex color values are not allowed. Consider using design tokens instead. For more information, visit: https://github.com/MetaMask/design-tokens or reach out to the design system team #metamask-design-system.`,
+        },
+      ],
+    },
+    // Testing template literals
+    {
+      code: `const borderColor = \`#abcdef\`;`,
+      errors: [
+        {
+          message: `'#abcdef' Hex color values are not allowed. Consider using design tokens instead. For more information, visit: https://github.com/MetaMask/design-tokens or reach out to the design system team #metamask-design-system.`,
+        },
+      ],
+    },
+    {
+      code: `const boxShadow = \`5px 5px 5px #888\`;`,
+      errors: [
+        {
+          message: `'#888' Hex color values are not allowed. Consider using design tokens instead. For more information, visit: https://github.com/MetaMask/design-tokens or reach out to the design system team #metamask-design-system.`,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## **Description**

This PR introduces the `@metamask/design-tokens/color-no-hex` rule to the ESLint plugin for MetaMask. The motivation behind this addition is to enforce a more centralized and manageable approach to color definitions across the MetaMask codebase. By discouraging the use of direct hexadecimal color values and promoting the adoption of design tokens generated styles, we aim to enhance consistency, scalability, and maintainability in styling. The solution involves a new ESLint rule that flags instances of hexadecimal color usage in favor of abstracted color definitions, encouraging developers to utilize the established design tokens.

## **Related issues**

Fixes: #6 

## **Manual testing steps**

To manually test this rule:
1. Pull this branch and use yarn link ([v1](https://classic.yarnpkg.com/lang/en/docs/cli/link/) or [v3](https://yarnpkg.com/cli/link) depending on your project) to link the `eslint-plugin-design-tokens` to your project. [See README](https://github.com/MetaMask/eslint-plugin-design-tokens?tab=readme-ov-file#metamaskeslint-plugin-design-tokens)
3. Set up the rule using the documentation in the PR
4. Run `yarn lint` or the respective linting script in your project

## **Screenshots/Recordings**

### Portfolio
Running the `color-no-hex` in portfolio

https://github.com/MetaMask/eslint-plugin-design-tokens/assets/8112138/548b3724-14b6-4d85-bdfb-0a5a89f872e9

### Mobile

Running the `color-no-hex` in mobile

https://github.com/MetaMask/eslint-plugin-design-tokens/assets/8112138/18a63600-00f6-41ab-912b-5e2607980a34


### Extension

https://github.com/MetaMask/eslint-plugin-design-tokens/assets/8112138/1072cc09-2f2b-4907-ab08-099b54d708ad

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests that cover the new rule's functionality.
- [x] I’ve documented the rule using [JSDoc](https://jsdoc.app/) format.
- [x] I’ve applied the right labels on the PR.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g., pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as ESLint output.
