### PR TITLE
chore: updating readme rule table with color-no-hex rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Then configure the rules you want to use within `rules` property of your `.eslin
 | Name                                                                              | Description                                                                       |
 | :-------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
 | [no-deprecated-classnames](docs/rules/no-deprecated-classnames.md)                | Enforce usage of up-to-date TailwindCSS class names, disallowing deprecated ones. |
+| [color-no-hex](docs/rules/color-no-hex.md)                                        | Prevent the use of hex color values.                                              |
 
 ## Contributing
 

--- a/docs/rules/color-no-hex.md
+++ b/docs/rules/color-no-hex.md
@@ -1,4 +1,4 @@
-# Prevent the use of static hex color values (`@metamask/design-tokens/color-no-hex`)
+# Prevent the use of hex color values (`@metamask/design-tokens/color-no-hex`)
 
 This rule discourages the direct use of hexadecimal color codes in your styles, promoting the adoption of a centralized approach to color management via [design tokens](https://github.com/MetaMask/design-tokens). By enforcing the use of [design tokens](https://github.com/MetaMask/design-tokens) for colors, this rule aids in ensuring consistency, design system alignment, scalability, and ease of maintenance across your project's UI.
 


### PR DESCRIPTION
### Description
Adds a link to the rule table in the README to `color-no-hex`

* Fixes #15 

### Before


https://github.com/MetaMask/eslint-plugin-design-tokens/assets/8112138/214ad518-46b5-4697-aa4d-f30319585767

### After


https://github.com/MetaMask/eslint-plugin-design-tokens/assets/8112138/b995988f-c6a1-48bc-a961-0662c9ae43a7



