### PR TITLE
feat: adding prefer-theme-color-classnames rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ Then configure the rules you want to use within `rules` property of your `.eslin
 
 > Remember that all rules from this plugin are prefixed by `"@metamask/design-tokens/"`
 
-| Name                                                                              | Description                                                                       |
-| :-------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- |
-| [no-deprecated-classnames](docs/rules/no-deprecated-classnames.md)                | Enforce usage of up-to-date TailwindCSS class names, disallowing deprecated ones. |
-| [color-no-hex](docs/rules/color-no-hex.md)                                        | Prevent the use of hex color values.                                              |
+| Name                                                                              | Description                                                                        |
+| :-------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------- |
+| [no-deprecated-classnames](docs/rules/no-deprecated-classnames.md)                | Enforce usage of up-to-date TailwindCSS class names, disallowing deprecated ones.  |
+| [color-no-hex](docs/rules/color-no-hex.md)                                        | Prevent the use of hex color values.                                               |
+| [prefer-theme-color-classnames](docs/rules/prefer-theme-color-classnames.md)      | Encourage the use of theme color class names instead of literal color class names. |
 
 ## Contributing
 

--- a/docs/rules/no-deprecated-classnames.md
+++ b/docs/rules/no-deprecated-classnames.md
@@ -27,7 +27,7 @@ Examples of **correct** code for this rule:
 
 This rule accepts an object option, where the keys are the deprecated class names and the values are messages suggesting the updated class names to use instead. This allows teams to customize the rule based on their specific design system and TailwindCSS configuration.
 
-## Example
+## Example Configuration
 
 ```json
 {

--- a/docs/rules/prefer-theme-color-classnames.md
+++ b/docs/rules/prefer-theme-color-classnames.md
@@ -64,7 +64,7 @@ You might choose not to enable this rule if:
 - Your project does not use utility classnames such as Tailwind
 - There are specific cases where the direct usage of literal color names is necessary and cannot be replaced with themed alternatives. This includes colors that should remain the same regardless of theme. In such cases, you can disable the rule for specific lines. For example, to disable the rule for the yellow of this star icon, you can use:
 
-```json
+```js
 <Star
   className={classnames({
     // eslint-disable-next-line @metamask/design-tokens/prefer-theme-color-classnames

--- a/docs/rules/prefer-theme-color-classnames.md
+++ b/docs/rules/prefer-theme-color-classnames.md
@@ -42,7 +42,7 @@ This rule accepts an optional single configuration object with the following pro
 ```json
 {
   "rules": {
-    "your-plugin/prefer-theme-color-classnames": [
+    "@metamask/design-tokens/prefer-theme-color-classnames": [
       "warn",
       {
         "discouragedColors": ["customColor", "anotherColor"] // Optional

--- a/docs/rules/prefer-theme-color-classnames.md
+++ b/docs/rules/prefer-theme-color-classnames.md
@@ -1,10 +1,10 @@
 # Encourage the Use of Theme Color Classnames (`@metamask/design-tokens/prefer-theme-color-classnames`)
 
-This rule encourages the use of theme-specific color classnames instead of hardcoded color names, promoting a centralized approach to color management via [design tokens](https://github.com/MetaMask/design-tokens). By advocating for the use of [design tokens](https://github.com/MetaMask/design-tokens) for colors, this rule helps ensure consistency, design system alignment, scalability, and ease of maintenance across your project's UI.
+This rule encourages the use of theme color classnames instead of literal color names, promoting theme safe and consistent color management via [design tokens](https://github.com/MetaMask/design-tokens). By advocating for the use of [design tokens](https://github.com/MetaMask/design-tokens) for colors, this rule helps ensure consistency, design system alignment, scalability, and ease of maintenance across your project's UI.
 
 ## Rule Details
 
-The `prefer-theme-color-classnames` rule is aimed at encouraging the use of theme-specific CSS class names over direct references to color names. This practice supports theming, reusability, and easier updates to the color palette.
+The `prefer-theme-color-classnames` rule is aimed at encouraging the use of theme color CSS class names over direct references to color names. This practice supports theming, reusability, and easier updates to the color palette.
 
 Examples of **incorrect** code for this rule:
 
@@ -24,7 +24,7 @@ Examples of **correct** code for this rule:
 
 ## Options
 
-This rule does not accept any options. Its primary purpose is to encourage the use of theme-specific color classnames instead of hardcoded color names.
+This rule does not accept any options. Its primary purpose is to encourage the use of theme color classnames instead of hardcoded color names.
 
 ## Example Configuration
 

--- a/docs/rules/prefer-theme-color-classnames.md
+++ b/docs/rules/prefer-theme-color-classnames.md
@@ -1,0 +1,57 @@
+# Encourage the Use of Theme Color Classnames (`@metamask/design-tokens/prefer-theme-color-classnames`)
+
+This rule encourages the use of theme-specific color classnames instead of hardcoded color names, promoting a centralized approach to color management via [design tokens](https://github.com/MetaMask/design-tokens). By advocating for the use of [design tokens](https://github.com/MetaMask/design-tokens) for colors, this rule helps ensure consistency, design system alignment, scalability, and ease of maintenance across your project's UI.
+
+## Rule Details
+
+The `prefer-theme-color-classnames` rule is aimed at encouraging the use of theme-specific CSS class names over direct references to color names. This practice supports theming, reusability, and easier updates to the color palette.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+// In a JSX file
+<div className="bg-slateGray-500">...</div>
+<div className="text-blue-600">...</div>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+// Using design token CSS variables
+<div className="bg-primary-default">...</div>
+<div className="text-error-default">...</div>
+```
+
+## Options
+
+This rule does not accept any options. Its primary purpose is to encourage the use of theme-specific color classnames instead of hardcoded color names.
+
+## Example Configuration
+
+```json
+{
+  "@metamask/design-tokens/prefer-theme-color-classnames": "warn"
+}
+```
+
+## When Not To Use It
+
+You might choose not to enable this rule if:
+
+- Your project has not adopted the MetaMask design system.
+- There are specific cases where the direct usage of hardcoded color names is necessary and cannot be replaced with themed alternatives. This includes legacy parts of your application or during a gradual migration to design tokens. In such cases, you can disable the rule for specific files or folders by adding overrides in your ESLint configuration. For example, to disable the rule in legacy files or folders, you can use:
+
+```json
+"overrides": [
+  {
+    "files": ["legacy/**/*.jsx", "another/path/to/specific/files/*"],
+    "rules": {
+      "@metamask/design-tokens/prefer-theme-color-classnames": "off"
+    }
+  }
+]
+```
+
+This configuration allows for selective application of the rule, accommodating necessary exceptions.
+
+Adopting this rule helps ensure that your project's color definitions are centralized and easily manageable, facilitating simpler adaptations or re-theming of your application as needed.

--- a/docs/rules/prefer-theme-color-classnames.md
+++ b/docs/rules/prefer-theme-color-classnames.md
@@ -4,7 +4,7 @@ This rule encourages the use of theme color classnames instead of literal color 
 
 ## Rule Details
 
-The `prefer-theme-color-classnames` rule is aimed at encouraging the use of theme color CSS class names over direct references to color names. This practice supports theming, reusability, and easier updates to the color palette.
+The `prefer-theme-color-classnames` rule is aimed at encouraging the use of CSS theme color class names over direct references to literal color names e.g. blue, red, green, slateGray, etc. This practice supports theming, reusability, and easier updates to the color palette.
 
 Examples of **incorrect** code for this rule:
 
@@ -17,20 +17,38 @@ Examples of **incorrect** code for this rule:
 Examples of **correct** code for this rule:
 
 ```jsx
-// Using design token CSS variables
-<div className="bg-primary-default">...</div>
-<div className="text-error-default">...</div>
+// Using design token theme color class names
+<div className="bg-default">...</div>
+<div className="text-primary-default">...</div>
 ```
 
 ## Options
 
-This rule does not accept any options. Its primary purpose is to encourage the use of theme color classnames instead of hardcoded color names.
+This rule accepts an optional single configuration object with the following properties:
 
-## Example Configuration
+- `discouragedColors`: An array of strings representing color names that should be avoided. Providing this array will override the default set of discouraged colors. The default colors considered discouraged are:
+  - `slateGray`
+  - `blue`
+  - `red`
+  - `gray`
+  - `midnight`
+  - `green`
+  - `orange`
+  - `black`
+  - `white`
+
+### Example configuration:
 
 ```json
 {
-  "@metamask/design-tokens/prefer-theme-color-classnames": "warn"
+  "rules": {
+    "your-plugin/prefer-theme-color-classnames": [
+      "warn",
+      {
+        "discouragedColors": ["customColor", "anotherColor"] // Optional
+      }
+    ]
+  }
 }
 ```
 
@@ -39,17 +57,17 @@ This rule does not accept any options. Its primary purpose is to encourage the u
 You might choose not to enable this rule if:
 
 - Your project has not adopted the MetaMask design system.
-- There are specific cases where the direct usage of hardcoded color names is necessary and cannot be replaced with themed alternatives. This includes legacy parts of your application or during a gradual migration to design tokens. In such cases, you can disable the rule for specific files or folders by adding overrides in your ESLint configuration. For example, to disable the rule in legacy files or folders, you can use:
+- Your project does not use utility classnames such as Tailwind
+- There are specific cases where the direct usage of literal color names is necessary and cannot be replaced with themed alternatives. This includes colors that should remain the same regardless of theme. In such cases, you can disable the rule for specific lines. For example, to disable the rule for the yellow of this star icon, you can use:
 
 ```json
-"overrides": [
-  {
-    "files": ["legacy/**/*.jsx", "another/path/to/specific/files/*"],
-    "rules": {
-      "@metamask/design-tokens/prefer-theme-color-classnames": "off"
-    }
-  }
-]
+<Star
+  className={classnames({
+    // eslint-disable-next-line @metamask/design-tokens/prefer-theme-color-classnames
+    'fill-yellow-500': isWatched,
+    'fill-icon-muted': !isWatched,
+  })}
+/>
 ```
 
 This configuration allows for selective application of the rule, accommodating necessary exceptions.

--- a/docs/rules/prefer-theme-color-classnames.md
+++ b/docs/rules/prefer-theme-color-classnames.md
@@ -27,15 +27,19 @@ Examples of **correct** code for this rule:
 This rule accepts an optional single configuration object with the following properties:
 
 - `discouragedColors`: An array of strings representing color names that should be avoided. Providing this array will override the default set of discouraged colors. The default colors considered discouraged are:
-  - `slateGray`
-  - `blue`
-  - `red`
-  - `gray`
-  - `midnight`
-  - `green`
-  - `orange`
-  - `black`
-  - `white`
+- `blue`
+- `red`
+- `gray`
+- `slateGray`
+- `green`
+- `orange`
+- `black`
+- `white`
+- `indigo`
+- `yellow`
+- `purple`
+- `pink`
+- `teal`
 
 ### Example configuration:
 

--- a/docs/rules/prefer-theme-color-classnames.md
+++ b/docs/rules/prefer-theme-color-classnames.md
@@ -41,7 +41,7 @@ This rule accepts an optional single configuration object with the following pro
 - `pink`
 - `teal`
 
-### Example configuration:
+### Example Configuration:
 
 ```json
 {
@@ -49,7 +49,7 @@ This rule accepts an optional single configuration object with the following pro
     "@metamask/design-tokens/prefer-theme-color-classnames": [
       "warn",
       {
-        "discouragedColors": ["customColor", "anotherColor"] // Optional
+        "discouragedColors": ["customColor", "anotherColor"]
       }
     ]
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
-import { noDeprecatedClassnames, colorNoHex } from './rules';
+import {
+  noDeprecatedClassnames,
+  colorNoHex,
+  preferThemeColorClassnames,
+} from './rules';
 
 export const rules = {
   'no-deprecated-classnames': noDeprecatedClassnames,
   'color-no-hex': colorNoHex,
+  'no-tailwind-brand-colors': preferThemeColorClassnames,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,5 @@ import {
 export const rules = {
   'no-deprecated-classnames': noDeprecatedClassnames,
   'color-no-hex': colorNoHex,
-  'no-tailwind-brand-colors': preferThemeColorClassnames,
+  'prefer-theme-color-classnames': preferThemeColorClassnames,
 };

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,2 +1,3 @@
 export { noDeprecatedClassnames } from './no-deprecated-classnames';
+export { preferThemeColorClassnames } from './prefer-theme-color-classnames';
 export { colorNoHex } from './color-no-hex';

--- a/src/rules/prefer-theme-color-classnames.ts
+++ b/src/rules/prefer-theme-color-classnames.ts
@@ -25,15 +25,19 @@ export const preferThemeColorClassnames: Rule.RuleModule = {
               minLength: 1, // This ensures that the string is not empty but does not prevent whitespace-only strings.
             },
             default: [
-              'slateGray',
               'blue',
               'red',
               'gray',
-              'midnight',
+              'slateGray',
               'green',
               'orange',
               'black',
               'white',
+              'indigo',
+              'yellow',
+              'purple',
+              'pink',
+              'teal',
             ],
           },
         },
@@ -49,15 +53,19 @@ export const preferThemeColorClassnames: Rule.RuleModule = {
 
     // Default to a list of discouraged color names if none are provided in the options.
     const discouragedColors: string[] = options.discouragedColors || [
-      'slateGray',
       'blue',
       'red',
       'gray',
-      'midnight',
+      'slateGray',
       'green',
       'orange',
       'black',
       'white',
+      'indigo',
+      'yellow',
+      'purple',
+      'pink',
+      'teal',
     ];
 
     // Validate discouragedColors to ensure no empty or whitespace-only strings

--- a/src/rules/prefer-theme-color-classnames.ts
+++ b/src/rules/prefer-theme-color-classnames.ts
@@ -1,5 +1,4 @@
 import type { Rule } from 'eslint';
-import type { Literal, TemplateLiteral, Node as ESTreeNode } from 'estree';
 
 /**
  * Rule to encourage the use of theme color class names instead of literal color class names.
@@ -90,7 +89,7 @@ export const preferThemeColorClassnames: Rule.RuleModule = {
      * @param value - The string value to check against the defined regex for discouraged color names. This could be the raw text from a Literal node or a segment of a TemplateLiteral node in the AST (Abstract Syntax Tree).
      * @param node - The AST node associated with the value; used for reporting the ESLint error. This node object is part of ESLint's traversal of JavaScript code and provides context like location and type, which are used in reporting and potentially fixing violations.
      */
-    function checkLiteralOrTemplateValue(value: string, node: ESTreeNode) {
+    function checkLiteralOrTemplateValue(value: string, node: any) {
       // Return early if the string to be checked is empty or only whitespace
       if (!value.trim()) {
         return;
@@ -108,12 +107,12 @@ export const preferThemeColorClassnames: Rule.RuleModule = {
     }
 
     return {
-      Literal(node: Literal) {
+      Literal(node) {
         if (typeof node.value === 'string') {
           checkLiteralOrTemplateValue(node.value, node);
         }
       },
-      TemplateLiteral(node: TemplateLiteral) {
+      TemplateLiteral(node) {
         node.quasis.forEach((quasi) => {
           checkLiteralOrTemplateValue(quasi.value.raw, quasi);
         });

--- a/src/rules/prefer-theme-color-classnames.ts
+++ b/src/rules/prefer-theme-color-classnames.ts
@@ -2,14 +2,14 @@ import type { Rule } from 'eslint';
 import type { Literal, TemplateLiteral, Node as ESTreeNode } from 'estree';
 
 /**
- * Rule to encourage the use of theme-specific color class names instead of literal color class names.
+ * Rule to encourage the use of theme color class names instead of literal color class names.
  */
 export const preferThemeColorClassnames: Rule.RuleModule = {
   meta: {
     type: 'suggestion',
     docs: {
       description:
-        'Encourage the use of theme-specific color class names instead of literal color class names.',
+        'Encourage the use of theme color class names instead of literal color class names.',
       recommended: true,
       url: 'https://github.com/MetaMask/eslint-plugin-design-tokens/blob/main/docs/rules/prefer-theme-color-classnames.md',
     },
@@ -41,7 +41,7 @@ export const preferThemeColorClassnames: Rule.RuleModule = {
       },
     ],
     messages: {
-      discouragedColorUsage: `'{{className}}' usage of literal color class names is discouraged. Consider using theme-specific class names instead.`,
+      discouragedColorUsage: `'{{className}}' usage of literal color class names is discouraged. Consider using theme color class names instead.`,
     },
   },
   create(context) {

--- a/src/rules/prefer-theme-color-classnames.ts
+++ b/src/rules/prefer-theme-color-classnames.ts
@@ -1,0 +1,115 @@
+import type { Rule } from 'eslint';
+import type { Literal, TemplateLiteral, Node as ESTreeNode } from 'estree';
+
+/**
+ * Rule to encourage the use of theme-specific color class names instead of literal color class names.
+ */
+export const preferThemeColorClassnames: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Encourage the use of theme-specific color class names instead of literal color class names.',
+      recommended: true,
+      url: 'https://github.com/MetaMask/eslint-plugin-design-tokens/blob/main/docs/rules/prefer-theme-color-classnames.md',
+    },
+    // Adding a schema to accept options
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          discouragedColors: {
+            type: 'array',
+            items: {
+              type: 'string',
+              minLength: 1, // This ensures that the string is not empty but does not prevent whitespace-only strings.
+            },
+            default: [
+              'slateGray',
+              'blue',
+              'red',
+              'gray',
+              'midnight',
+              'green',
+              'orange',
+              'black',
+              'white',
+            ],
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      discouragedColorUsage: `'{{className}}' usage of literal color class names is discouraged. Consider using theme-specific class names instead.`,
+    },
+  },
+  create(context) {
+    const options = context.options[0] || {};
+
+    // Default to a list of discouraged color names if none are provided in the options.
+    const discouragedColors: string[] = options.discouragedColors || [
+      'slateGray',
+      'blue',
+      'red',
+      'gray',
+      'midnight',
+      'green',
+      'orange',
+      'black',
+      'white',
+    ];
+
+    // Validate discouragedColors to ensure no empty or whitespace-only strings
+    const validColors = discouragedColors.filter(
+      (color) => color.trim().length > 0,
+    );
+
+    if (validColors.length === 0) {
+      return {}; // Exit early if no valid colors are provided
+    }
+
+    // Create a regex that matches class names containing any of the discouraged color names.
+    const colorRegex = new RegExp(
+      `\\b(\\w+-)?(${discouragedColors.join('|')})-?\\d*\\b`,
+      'iu',
+    );
+
+    /**
+     * Checks if a given string value contains discouraged literal color names in CSS class names and reports them.
+     * This function is designed to handle both literals and template literals, capturing classes that violate the rules.
+     *
+     * @param value - The string value to check against the defined regex for discouraged color names. This could be the raw text from a Literal node or a segment of a TemplateLiteral node in the AST (Abstract Syntax Tree).
+     * @param node - The AST node associated with the value; used for reporting the ESLint error. This node object is part of ESLint's traversal of JavaScript code and provides context like location and type, which are used in reporting and potentially fixing violations.
+     */
+    function checkLiteralOrTemplateValue(value: string, node: ESTreeNode) {
+      // Return early if the string to be checked is empty or only whitespace
+      if (!value.trim()) {
+        return;
+      }
+      const matches = value.match(colorRegex);
+      if (matches?.[0]) {
+        context.report({
+          node,
+          messageId: 'discouragedColorUsage',
+          data: {
+            className: matches[0],
+          },
+        });
+      }
+    }
+
+    return {
+      Literal(node: Literal) {
+        if (typeof node.value === 'string') {
+          checkLiteralOrTemplateValue(node.value, node);
+        }
+      },
+      TemplateLiteral(node: TemplateLiteral) {
+        node.quasis.forEach((quasi) => {
+          checkLiteralOrTemplateValue(quasi.value.raw, quasi);
+        });
+      },
+    };
+  },
+};

--- a/tests/rules/color-no-hex.spec.ts
+++ b/tests/rules/color-no-hex.spec.ts
@@ -1,6 +1,6 @@
 import { RuleTester } from 'eslint';
 
-import { colorNoHex } from '../../src/rules/color-no-hex'; // Adjust this import path to where your rule is actually defined
+import { colorNoHex } from '../../src/rules/color-no-hex';
 
 const ruleTester = new RuleTester({
   // eslint-disable-next-line no-restricted-globals

--- a/tests/rules/prefer-theme-color-classnames.spec.ts
+++ b/tests/rules/prefer-theme-color-classnames.spec.ts
@@ -30,45 +30,20 @@ ruleTester.run('prefer-theme-color-classnames', preferThemeColorClassnames, {
 
   invalid: [
     {
-      code: `const className = "bg-slateGray-500";`,
+      code: `const className = "bg-customColor-500";`,
       options: [
         {
-          discouragedColors: [
-            'slateGray',
-            'blue',
-            'red',
-            'gray',
-            'midnight',
-            'green',
-            'orange',
-            'black',
-            'white',
-          ],
+          discouragedColors: ['customColor'],
         },
       ],
       errors: [
         {
-          message: `'bg-slateGray-500' usage of literal color class names is discouraged. Consider using theme color class names instead.`,
+          message: `'bg-customColor-500' usage of literal color class names is discouraged. Consider using theme color class names instead.`,
         },
       ],
     },
     {
       code: `const className = "border-blue-200";`,
-      options: [
-        {
-          discouragedColors: [
-            'slateGray',
-            'blue',
-            'red',
-            'gray',
-            'midnight',
-            'green',
-            'orange',
-            'black',
-            'white',
-          ],
-        },
-      ],
       errors: [
         {
           message: `'border-blue-200' usage of literal color class names is discouraged. Consider using theme color class names instead.`,
@@ -77,21 +52,6 @@ ruleTester.run('prefer-theme-color-classnames', preferThemeColorClassnames, {
     },
     {
       code: `const className = "text-red-600";`,
-      options: [
-        {
-          discouragedColors: [
-            'slateGray',
-            'blue',
-            'red',
-            'gray',
-            'midnight',
-            'green',
-            'orange',
-            'black',
-            'white',
-          ],
-        },
-      ],
       errors: [
         {
           message: `'text-red-600' usage of literal color class names is discouraged. Consider using theme color class names instead.`,
@@ -99,25 +59,10 @@ ruleTester.run('prefer-theme-color-classnames', preferThemeColorClassnames, {
       ],
     },
     {
-      code: `const templateString = \`bg-midnight-\${opacity}\`;`,
-      options: [
-        {
-          discouragedColors: [
-            'slateGray',
-            'blue',
-            'red',
-            'gray',
-            'midnight',
-            'green',
-            'orange',
-            'black',
-            'white',
-          ],
-        },
-      ],
+      code: `const templateString = \`bg-blue-\${opacity}\`;`,
       errors: [
         {
-          message: `'bg-midnight' usage of literal color class names is discouraged. Consider using theme color class names instead.`,
+          message: `'bg-blue' usage of literal color class names is discouraged. Consider using theme color class names instead.`,
         },
       ],
     },

--- a/tests/rules/prefer-theme-color-classnames.spec.ts
+++ b/tests/rules/prefer-theme-color-classnames.spec.ts
@@ -48,7 +48,7 @@ ruleTester.run('prefer-theme-color-classnames', preferThemeColorClassnames, {
       ],
       errors: [
         {
-          message: `'bg-slateGray-500' usage of literal color class names is discouraged. Consider using theme-specific class names instead.`,
+          message: `'bg-slateGray-500' usage of literal color class names is discouraged. Consider using theme color class names instead.`,
         },
       ],
     },
@@ -71,7 +71,7 @@ ruleTester.run('prefer-theme-color-classnames', preferThemeColorClassnames, {
       ],
       errors: [
         {
-          message: `'border-blue-200' usage of literal color class names is discouraged. Consider using theme-specific class names instead.`,
+          message: `'border-blue-200' usage of literal color class names is discouraged. Consider using theme color class names instead.`,
         },
       ],
     },
@@ -94,7 +94,7 @@ ruleTester.run('prefer-theme-color-classnames', preferThemeColorClassnames, {
       ],
       errors: [
         {
-          message: `'text-red-600' usage of literal color class names is discouraged. Consider using theme-specific class names instead.`,
+          message: `'text-red-600' usage of literal color class names is discouraged. Consider using theme color class names instead.`,
         },
       ],
     },
@@ -117,7 +117,7 @@ ruleTester.run('prefer-theme-color-classnames', preferThemeColorClassnames, {
       ],
       errors: [
         {
-          message: `'bg-midnight' usage of literal color class names is discouraged. Consider using theme-specific class names instead.`,
+          message: `'bg-midnight' usage of literal color class names is discouraged. Consider using theme color class names instead.`,
         },
       ],
     },

--- a/tests/rules/prefer-theme-color-classnames.spec.ts
+++ b/tests/rules/prefer-theme-color-classnames.spec.ts
@@ -1,6 +1,6 @@
 import { RuleTester } from 'eslint';
 
-import { preferThemeColorClassnames } from '../../src/rules/prefer-theme-color-classnames'; // Adjust the path as necessary
+import { preferThemeColorClassnames } from '../../src/rules/prefer-theme-color-classnames';
 
 const ruleTester = new RuleTester({
   // eslint-disable-next-line no-restricted-globals

--- a/tests/rules/prefer-theme-color-classnames.spec.ts
+++ b/tests/rules/prefer-theme-color-classnames.spec.ts
@@ -1,0 +1,125 @@
+import { RuleTester } from 'eslint';
+
+import { preferThemeColorClassnames } from '../../src/rules/prefer-theme-color-classnames'; // Adjust the path as necessary
+
+const ruleTester = new RuleTester({
+  // eslint-disable-next-line no-restricted-globals
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('prefer-theme-color-classnames', preferThemeColorClassnames, {
+  valid: [
+    { code: `const className = "bg-primary-default";` },
+    { code: `const className = "text-default";` },
+    { code: `const templateString = \`bg-\${colorValue}\`;` },
+    { code: `const className = "other-non-color-class-name";` },
+    // This is an example where default discouraged colors are overridden so default colors are not discouraged
+    {
+      code: `const className = "bg-blue-500";`,
+      options: [{ discouragedColors: ['random-override'] }],
+    },
+    {
+      code: `const className = "bg-blue-500";`,
+      options: [{ discouragedColors: [' '] }],
+    },
+  ],
+
+  invalid: [
+    {
+      code: `const className = "bg-slateGray-500";`,
+      options: [
+        {
+          discouragedColors: [
+            'slateGray',
+            'blue',
+            'red',
+            'gray',
+            'midnight',
+            'green',
+            'orange',
+            'black',
+            'white',
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: `'bg-slateGray-500' usage of literal color class names is discouraged. Consider using theme-specific class names instead.`,
+        },
+      ],
+    },
+    {
+      code: `const className = "border-blue-200";`,
+      options: [
+        {
+          discouragedColors: [
+            'slateGray',
+            'blue',
+            'red',
+            'gray',
+            'midnight',
+            'green',
+            'orange',
+            'black',
+            'white',
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: `'border-blue-200' usage of literal color class names is discouraged. Consider using theme-specific class names instead.`,
+        },
+      ],
+    },
+    {
+      code: `const className = "text-red-600";`,
+      options: [
+        {
+          discouragedColors: [
+            'slateGray',
+            'blue',
+            'red',
+            'gray',
+            'midnight',
+            'green',
+            'orange',
+            'black',
+            'white',
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: `'text-red-600' usage of literal color class names is discouraged. Consider using theme-specific class names instead.`,
+        },
+      ],
+    },
+    {
+      code: `const templateString = \`bg-midnight-\${opacity}\`;`,
+      options: [
+        {
+          discouragedColors: [
+            'slateGray',
+            'blue',
+            'red',
+            'gray',
+            'midnight',
+            'green',
+            'orange',
+            'black',
+            'white',
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: `'bg-midnight' usage of literal color class names is discouraged. Consider using theme-specific class names instead.`,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
# Description

This PR introduces the `prefer-theme-color-classnames` rule to the `@metamask/eslint-plugin-design-tokens` plugin, a strategic move aimed at enhancing code quality and design system adherence across our projects, starting with the portfolio codebase. This rule is designed to discourage the use of literal brand color names such as `blue`, `red`, `gray`, `green`, etc., promoting instead the use of theme color classnames derived from our design tokens. This ensures that our styling remains consistent with our design system, improves accessibility, and facilitates easier theming and updates. While initially targeted at the portfolio codebase, this rule is versatile enough to be applied to other Tailwind-based projects, such as the embedded wallet codebase.

## Type of Change

- [x] Chore (non-breaking change like a refactor, test update, etc.)

## Related Issue

https://github.com/MetaMask/eslint-plugin-design-tokens/issues/12

## Testing

To test the integration and effectiveness of the `prefer-theme-color-classnames` rule:
1. In the `eslint-plugin-design-tokens` repository, run `YARN_IGNORE_PATH=1 yarn link` to locally link the updated plugin.
2. In the portfolio codebase, run `yarn link @metamask/eslint-plugin-design-tokens` to use the locally linked version of the plugin.
3. Add the `prefer-theme-color-classnames` rule to the portfolio's `.eslintrc` file to enforce the new linting rule.
4. Execute `yarn lint:check` within the portfolio codebase to identify and address any instances where literal brand color names are used instead of the recommended theme color classnames.

### Additional Test Cases:
- [x] Ensure that the `prefer-theme-color-classnames` rule accurately flags instances of literal brand color names.
- [x] Replace flagged instances with the appropriate theme color classnames and rerun `yarn lint:check` to confirm that the issues are resolved.

## Checklist

- [x] I have successfully integrated the `prefer-theme-color-classnames` rule into the `@metamask/eslint-plugin-design-tokens`.
- [x] My changes generate no new warnings or errors in the development environment.
- [x] I have performed a self-review of my code, ensuring it aligns with our design system standards and contributes positively to the UI/UX.

## Screenshots/Screencasts

### After


https://github.com/MetaMask/eslint-plugin-design-tokens/assets/8112138/0c9b40e0-bdd5-4b06-8572-34efd32680c2


